### PR TITLE
* 将 leftBarButtonItem backAction 绑定到 viewController，解决 #19  crash 问题

### DIFF
--- a/JTNavigationController/JTNavigationController/Classes/JTNavigationController.h
+++ b/JTNavigationController/JTNavigationController/Classes/JTNavigationController.h
@@ -25,3 +25,10 @@
 @property (nonatomic, copy, readonly) NSArray *jt_viewControllers;
 
 @end
+
+
+@interface UINavigationController (JTExtention)
+
+@property (nonatomic, readonly) UINavigationControllerOperation jt_operation;
+
+@end

--- a/JTNavigationController/JTNavigationController/Classes/JTNavigationController.h
+++ b/JTNavigationController/JTNavigationController/Classes/JTNavigationController.h
@@ -19,9 +19,7 @@
 @interface JTNavigationController : UINavigationController
 
 @property (nonatomic, strong) UIImage *backButtonImage;
-
 @property (nonatomic, assign) BOOL fullScreenPopGestureEnabled;
-
 @property (nonatomic, copy, readonly) NSArray *jt_viewControllers;
 
 @end
@@ -30,5 +28,7 @@
 @interface UINavigationController (JTExtention)
 
 @property (nonatomic, readonly) UINavigationControllerOperation jt_operation;
+
+- (NSArray *)jt_popViewControllerTwiceAnimated:(BOOL)animated;
 
 @end

--- a/JTNavigationController/JTNavigationController/Classes/JTNavigationController.m
+++ b/JTNavigationController/JTNavigationController/Classes/JTNavigationController.m
@@ -11,6 +11,14 @@
 
 #define kDefaultBackImageName @"backImage"
 
+@interface JTNavigationController () <UINavigationControllerDelegate, UIGestureRecognizerDelegate>
+
+@property (nonatomic, strong) UIPanGestureRecognizer *popPanGesture;
+@property (nonatomic, strong) id popGestureDelegate;
+@property (nonatomic, assign) UINavigationControllerOperation jt_operation;
+
+@end
+
 #pragma mark - JTWrapNavigationController
 
 @interface JTWrapNavigationController : UINavigationController
@@ -34,23 +42,21 @@
 }
 
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
-    
     viewController.jt_navigationController = (JTNavigationController *)self.navigationController;
     viewController.jt_fullScreenPopGestureEnabled = viewController.jt_navigationController.fullScreenPopGestureEnabled;
     
     UIImage *backButtonImage = viewController.jt_navigationController.backButtonImage;
-    
     if (!backButtonImage) {
         backButtonImage = [UIImage imageNamed:kDefaultBackImageName];
     }
     
-    viewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:backButtonImage style:UIBarButtonItemStylePlain target:self action:@selector(didTapBackButton)];
+    viewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:backButtonImage
+                                                                                       style:UIBarButtonItemStylePlain
+                                                                                      target:viewController
+                                                                                      action:@selector(jt_didTapBackButton:)];
     
-    [self.navigationController pushViewController:[JTWrapViewController wrapViewControllerWithViewController:viewController] animated:animated];
-}
-
-- (void)didTapBackButton {
-    [self.navigationController popViewControllerAnimated:YES];
+    JTWrapViewController* wrapController = [JTWrapViewController wrapViewControllerWithViewController:viewController];
+    [self.navigationController pushViewController:wrapController animated:animated];
 }
 
 -(void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion{
@@ -136,14 +142,6 @@ static NSValue *jt_tabBarRectValue;
 
 #pragma mark - JTNavigationController
 
-@interface JTNavigationController () <UINavigationControllerDelegate, UIGestureRecognizerDelegate>
-
-@property (nonatomic, strong) UIPanGestureRecognizer *popPanGesture;
-
-@property (nonatomic, strong) id popGestureDelegate;
-
-@end
-
 @implementation JTNavigationController
 
 - (instancetype)initWithRootViewController:(UIViewController *)rootViewController {
@@ -172,9 +170,14 @@ static NSValue *jt_tabBarRectValue;
     SEL action = NSSelectorFromString(@"handleNavigationTransition:");
     self.popPanGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self.popGestureDelegate action:action];
     self.popPanGesture.maximumNumberOfTouches = 1;
-    
 }
 
+- (UIViewController *)popViewControllerAnimated:(BOOL)animated {
+    UIViewController* result = [super popViewControllerAnimated:animated];
+    self.jt_operation = UINavigationControllerOperationPop;
+    
+    return result;
+}
 
 #pragma mark - UINavigationControllerDelegate
 
@@ -217,6 +220,20 @@ static NSValue *jt_tabBarRectValue;
         [viewControllers addObject:wrapViewController.rootViewController];
     }
     return viewControllers.copy;
+}
+
+@end
+
+
+@implementation UINavigationController (JTExtention)
+
+- (UINavigationControllerOperation)jt_operation {
+    if ([self isKindOfClass:[JTNavigationController class]]) {
+        JTNavigationController* controller = (JTNavigationController *)self;
+        return controller.jt_operation;
+    }
+    
+    return UINavigationControllerOperationNone;
 }
 
 @end

--- a/JTNavigationController/JTNavigationController/Classes/JTNavigationController.m
+++ b/JTNavigationController/JTNavigationController/Classes/JTNavigationController.m
@@ -45,6 +45,10 @@
 }
 
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
+    if (![self.navigationController isKindOfClass:[JTNavigationController class]]) {
+        return;
+    }
+    
     viewController.jt_navigationController = (JTNavigationController *)self.navigationController;
     viewController.jt_fullScreenPopGestureEnabled = viewController.jt_navigationController.fullScreenPopGestureEnabled;
     viewController.jt_navigationController.jt_operation = UINavigationControllerOperationPush;
@@ -65,7 +69,7 @@
 
 -(void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion{
     [self.navigationController dismissViewControllerAnimated:flag completion:completion];
-    self.viewControllers.firstObject.jt_navigationController=nil;
+    self.viewControllers.firstObject.jt_navigationController = nil;
 }
 
 @end
@@ -77,6 +81,10 @@ static NSValue *jt_tabBarRectValue;
 @implementation JTWrapViewController
 
 + (JTWrapViewController *)wrapViewControllerWithViewController:(UIViewController *)viewController {
+    if (!viewController) {
+        NSLog(@"%s %d Warning: wrapViewControllerWithViewController:nil", __FUNCTION__, __LINE__);
+        return nil;
+    }
     
     JTWrapNavigationController *wrapNavController = [[JTWrapNavigationController alloc] init];
     wrapNavController.viewControllers = @[viewController];
@@ -146,7 +154,9 @@ static NSValue *jt_tabBarRectValue;
 
 #pragma mark - JTNavigationController
 
-@implementation JTNavigationController
+@implementation JTNavigationController {
+    BOOL _shouldNextGestureFailed;
+}
 
 - (instancetype)initWithRootViewController:(UIViewController *)rootViewController {
     if (self = [super init]) {
@@ -181,6 +191,35 @@ static NSValue *jt_tabBarRectValue;
     self.jt_operation = UINavigationControllerOperationPop;
     
     return result;
+}
+
+#pragma mark - 横屏控制支持 
+
+- (BOOL)shouldAutorotate {
+    if (self.jt_viewControllers.count > 0) {
+        UIViewController* root = [self.jt_viewControllers firstObject];
+        return [root shouldAutorotate];
+    }
+    
+    return [super shouldAutorotate];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    if (self.jt_viewControllers.count > 0) {
+        UIViewController* root = [self.jt_viewControllers firstObject];
+        return [root supportedInterfaceOrientations];
+    }
+    
+    return [super supportedInterfaceOrientations];
+}
+
+- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
+    if (self.jt_viewControllers.count > 0) {
+        UIViewController* root = [self.jt_viewControllers firstObject];
+        return [root preferredInterfaceOrientationForPresentation];
+    }
+    
+    return [super preferredInterfaceOrientationForPresentation];
 }
 
 #pragma mark - UINavigationControllerDelegate

--- a/JTNavigationController/JTNavigationController/Classes/JTNavigationController.m
+++ b/JTNavigationController/JTNavigationController/Classes/JTNavigationController.m
@@ -28,15 +28,18 @@
 @implementation JTWrapNavigationController
 
 - (UIViewController *)popViewControllerAnimated:(BOOL)animated {
+    self.jt_navigationController.jt_operation = UINavigationControllerOperationPop;
     return [self.navigationController popViewControllerAnimated:animated];
 }
 
 - (NSArray<UIViewController *> *)popToRootViewControllerAnimated:(BOOL)animated {
+    self.jt_navigationController.jt_operation = UINavigationControllerOperationPop;
     return [self.navigationController popToRootViewControllerAnimated:animated];
 }
 
 - (NSArray<UIViewController *> *)popToViewController:(UIViewController *)viewController animated:(BOOL)animated {
     JTNavigationController *jt_navigationController = viewController.jt_navigationController;
+    jt_navigationController.jt_operation = UINavigationControllerOperationPop;
     NSInteger index = [jt_navigationController.jt_viewControllers indexOfObject:viewController];
     return [self.navigationController popToViewController:jt_navigationController.viewControllers[index] animated:animated];
 }
@@ -44,6 +47,7 @@
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
     viewController.jt_navigationController = (JTNavigationController *)self.navigationController;
     viewController.jt_fullScreenPopGestureEnabled = viewController.jt_navigationController.fullScreenPopGestureEnabled;
+    viewController.jt_navigationController.jt_operation = UINavigationControllerOperationPush;
     
     UIImage *backButtonImage = viewController.jt_navigationController.backButtonImage;
     if (!backButtonImage) {

--- a/JTNavigationController/JTNavigationController/Classes/JTNavigationController.m
+++ b/JTNavigationController/JTNavigationController/Classes/JTNavigationController.m
@@ -240,4 +240,24 @@ static NSValue *jt_tabBarRectValue;
     return UINavigationControllerOperationNone;
 }
 
+- (NSArray *)jt_popViewControllerTwiceAnimated:(BOOL)animated {
+    if (![self.navigationController isKindOfClass:[JTNavigationController class]]) {
+        return nil;
+    }
+    
+    JTNavigationController* jt_navigationController = (JTNavigationController *)self.navigationController;
+    NSArray* viewControllers = jt_navigationController.jt_viewControllers;
+    NSInteger count = viewControllers.count;
+    NSInteger index = count - 3;
+    if (index < 0) {
+        // 出错了，没办法pop两次
+        UIViewController* controller = [self popViewControllerAnimated:animated];
+        NSArray* controllers = @[controller];
+        return controllers;
+    }
+    
+    UIViewController* viewController = [viewControllers objectAtIndex:index];
+    return [self popToViewController:viewController animated:animated];
+}
+
 @end

--- a/JTNavigationController/JTNavigationController/Classes/UIViewController+JTNavigationExtension.h
+++ b/JTNavigationController/JTNavigationController/Classes/UIViewController+JTNavigationExtension.h
@@ -12,7 +12,8 @@
 @interface UIViewController (JTNavigationExtension)
 
 @property (nonatomic, assign) BOOL jt_fullScreenPopGestureEnabled;
-
 @property (nonatomic, strong) JTNavigationController *jt_navigationController;
+
+- (void)jt_didTapBackButton:(id)sender;
 
 @end

--- a/JTNavigationController/JTNavigationController/Classes/UIViewController+JTNavigationExtension.m
+++ b/JTNavigationController/JTNavigationController/Classes/UIViewController+JTNavigationExtension.m
@@ -7,6 +7,7 @@
 //
 
 #import "UIViewController+JTNavigationExtension.h"
+#import "JTNavigationController.h"
 #import <objc/runtime.h>
 
 @implementation UIViewController (JTNavigationExtension)
@@ -24,7 +25,7 @@
 }
 
 - (void)setJt_navigationController:(JTNavigationController *)navigationController {
-    objc_setAssociatedObject(self, @selector(jt_navigationController), navigationController, OBJC_ASSOCIATION_RETAIN);
+    objc_setAssociatedObject(self, @selector(jt_navigationController), navigationController, OBJC_ASSOCIATION_ASSIGN);
 }
 
 - (void)jt_didTapBackButton:(id)sender {

--- a/JTNavigationController/JTNavigationController/Classes/UIViewController+JTNavigationExtension.m
+++ b/JTNavigationController/JTNavigationController/Classes/UIViewController+JTNavigationExtension.m
@@ -27,4 +27,8 @@
     objc_setAssociatedObject(self, @selector(jt_navigationController), navigationController, OBJC_ASSOCIATION_RETAIN);
 }
 
+- (void)jt_didTapBackButton:(id)sender {
+    [self.navigationController popViewControllerAnimated:YES];
+}
+
 @end


### PR DESCRIPTION
#19 问题由于手动 remove 某个

JTWrapNavigationController，手动点击controller左上角的返回时候，这个返回的事件依然是绑定到
JTWrapNavigationController 里面，已经不存在了。改为将事件绑定到 viewController 里面可以解决
